### PR TITLE
Added sleep and grep

### DIFF
--- a/grep.bat
+++ b/grep.bat
@@ -1,0 +1,1 @@
+@findstr /R %*

--- a/sleep.bat
+++ b/sleep.bat
@@ -1,0 +1,1 @@
+@timeout /NOBREAK %*


### PR DESCRIPTION
You can now do:
```
cat README.md | grep nix
```
Note: the `sleep` shows a countdown that you can't get rid of